### PR TITLE
Fix typo on Homepage

### DIFF
--- a/src/Views/Home/index.js
+++ b/src/Views/Home/index.js
@@ -86,7 +86,7 @@ class HomeView extends Component {
             htmlFor="file"
             className="inputLabel"
           >
-            or, bowse a file from computer
+            or, browse a file from computer
           </label>
         </Dropzone>
 


### PR DESCRIPTION
Changed "bowse" to "browse". Recommend re-uploading the preview images on the README as well.